### PR TITLE
clean up triggerHook tree after new activated async handle is found

### DIFF
--- a/src/asyncctx/ContinuationLocalStorage.ts
+++ b/src/asyncctx/ContinuationLocalStorage.ts
@@ -99,6 +99,7 @@ export class ContinuationLocalStorage<T> {
             }
           }
           hi.activated = true;
+          hi.triggerHook = undefined;
         } else {
           // since node 11 this seems to be not required anymore:
           this._currId = ROOT_ID;
@@ -199,6 +200,18 @@ export class ContinuationLocalStorage<T> {
   public getTriggerId(id: number = this.currId): number | undefined {
     const hi = this.idHookMap.get(id);
     return hi ? hi.triggerId : undefined;
+  }
+
+  /**
+   * Get the hook info of the caller for testing purposes
+   *
+   * @param {number} [id=this.currId]
+   * @returns {(number|undefined)}
+   */
+  /* istanbul ignore next */
+  public getHookInfo(id: number = this.currId): HookInfo<T> | undefined {
+    const hi = this.idHookMap.get(id);
+    return hi;
   }
 
   /**

--- a/src/asyncctx/spec/continuation.spec.ts
+++ b/src/asyncctx/spec/continuation.spec.ts
@@ -19,6 +19,16 @@ function debugId(prefix: string): void {
   cls.debugId('TEST: ' + prefix);
 }
 
+function triggerHookLength(): number {
+  let hookInfo = cls.getHookInfo();
+  let length = 0;
+  while (hookInfo) {
+    hookInfo = hookInfo.triggerHook;
+    length += 1;
+  }
+  return length;
+}
+
 describe('test continuation but enable hooks right before each test:', () => {
   beforeEach((done) => {
     if (clsNew) {
@@ -380,6 +390,20 @@ describe('test continuation but enable hooks right before each test:', () => {
         done();
       });
   });
+
+  it('continuous local storage should only maintain triggerHook list up to first activated node', (done) => {
+    cls.enable();
+    setImmediate(() => {
+      setImmediate(() => {
+        const length = triggerHookLength();
+        expect(length).toBe(
+            1,
+            `triggerHook length (${length}) is not the expected length (1)`,
+          );
+        done();
+      });
+    });
+  });
 });
 
 // #######################################################################################################################
@@ -724,5 +748,18 @@ describe('test continuation with hooks enabled long before running these tests:'
       .then((val) => {
         done();
       });
+  });
+
+  it('continuous local storage should only maintain triggerHook tree up to first activated node', (done) => {
+    setImmediate(() => {
+      setImmediate(() => {
+        const length = triggerHookLength();
+        expect(length).toBe(
+            1,
+            `triggerHook length (${length}) is not the expected length (1)`,
+          );
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
There is a corner-case that causes memory to be leaked over time.

The root cause of the issue is that `ContinuationLocalStorage` keeps track of the hook info as a linked list (to be able to find the correct context for eg. promises). The problem is that even if `destroy` hook for an async resource is called, the triggerHook object is still kept in memory if it's referenced by other triggered async resources.

Most of the time this is fine, because when all of the async resources in a given list finishes, node GC sees that the list is no longer referred and can be collected.

However it's not uncommon to have "infinite asynchronous recursion", for example by having a Promise chain that keeps on adding a new promise to be awaited for in the the then handler.

By having such a construct,`ContinuationLocalStorage` starts leaking memory, because that linked list of triggerHooks is always going to be referred from `idHookMap` and it's going to grow infinitely.

The fix is quite simple. Since `ContinuationLocalStorage` is only interested in the last activated resource, we can simply discard the old triggerHook list whenever we find a new activated resource. Also added a test to make sure we don't keep track of the old resources unnecessarily.

We had a production system that leaked hundreds of megabytes of memory over days, and I verified that with this fix the issue is gone.